### PR TITLE
Add CRUD smoke tests for Filament resources

### DIFF
--- a/tests/Feature/Modules/Core/CategoryCrudTest.php
+++ b/tests/Feature/Modules/Core/CategoryCrudTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature\Modules\Core;
+
+use App\Models\User;
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Modules\Core\Filament\Resources\CategoryResource\Pages\ListCategories;
+use Modules\Core\Models\Category;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * @group smoke
+ */
+class CategoryCrudTest extends TestCase
+{
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Model::unguard();
+
+        $this->user = User::factory()->create();
+
+        $this->user->forceFill([
+            'resource_permission' => 'global',
+        ])->save();
+    }
+
+    #[Test]
+    public function it_lists_categories(): void
+    {
+        /* Arrange */
+        $visibleCategory = Category::factory()->create();
+        $otherCategory   = Category::factory()->create();
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(ListCategories::class);
+
+        /* Assert */
+        $component->assertCanSeeTableRecords([$visibleCategory])
+            ->assertCanSeeTableRecords([$otherCategory]);
+    }
+
+    #[Test]
+    public function it_creates_a_category(): void
+    {
+        /* Arrange */
+        $payload = [
+            'name' => 'Test Category ' . Str::random(5),
+        ];
+
+        /* Act */
+        Livewire::actingAs($this->user)
+            ->test(ListCategories::class)
+            ->mountAction('create')
+            ->fillForm($payload)
+            ->callMountedAction();
+
+        /* Assert */
+        $this->assertDatabaseHas('products_categories', [
+            'name' => $payload['name'],
+        ]);
+    }
+
+    #[Test]
+    public function it_updates_a_category(): void
+    {
+        /* Arrange */
+        $category = Category::factory()->create();
+
+        $payload = [
+            'name' => 'Updated ' . $category->name,
+        ];
+
+        /* Act */
+        Livewire::actingAs($this->user)
+            ->test(ListCategories::class)
+            ->mountAction(TestAction::make('edit')->table($category), $payload)
+            ->fillForm($payload)
+            ->callMountedAction();
+
+        /* Assert */
+        $this->assertDatabaseHas('products_categories', [
+            'id'   => $category->id,
+            'name' => $payload['name'],
+        ]);
+    }
+
+    #[Test]
+    public function it_deletes_a_category(): void
+    {
+        /* Arrange */
+        $category = Category::factory()->create();
+
+        /* Act */
+        Livewire::actingAs($this->user)
+            ->test(ListCategories::class)
+            ->mountAction(TestAction::make('delete')->table($category))
+            ->callMountedAction();
+
+        /* Assert */
+        $this->assertDatabaseMissing('products_categories', [
+            'id' => $category->id,
+        ]);
+    }
+}

--- a/tests/Feature/Modules/Core/DepartmentCrudTest.php
+++ b/tests/Feature/Modules/Core/DepartmentCrudTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Tests\Feature\Modules\Core;
+
+use App\Models\User;
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Modules\Core\Filament\Resources\DepartmentResource\Pages\ListDepartments;
+use Modules\Core\Models\Department;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * @group smoke
+ */
+class DepartmentCrudTest extends TestCase
+{
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Model::unguard();
+
+        $this->user = User::factory()->create();
+
+        $this->user->forceFill([
+            'resource_permission' => 'global',
+        ])->save();
+    }
+
+    #[Test]
+    public function it_lists_departments(): void
+    {
+        /* Arrange */
+        $department = Department::create([
+            'name'       => 'Operations',
+            'color'      => '#336699',
+            'creator_id' => $this->user->id,
+        ]);
+
+        $otherDepartment = Department::create([
+            'name'       => 'Support',
+            'color'      => '#663399',
+            'creator_id' => $this->user->id,
+        ]);
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(ListDepartments::class);
+
+        /* Assert */
+        $component->assertCanSeeTableRecords([$department, $otherDepartment]);
+    }
+
+    #[Test]
+    public function it_creates_a_department(): void
+    {
+        /* Arrange */
+        $payload = [
+            'name'  => 'Department ' . Str::random(5),
+            'color' => '#123456',
+        ];
+
+        /* Act */
+        Livewire::actingAs($this->user)
+            ->test(ListDepartments::class)
+            ->mountAction('create')
+            ->fillForm($payload)
+            ->callMountedAction();
+
+        /* Assert */
+        $this->assertDatabaseHas('employees_departments', [
+            'name' => $payload['name'],
+        ]);
+    }
+
+    #[Test]
+    public function it_updates_a_department(): void
+    {
+        /* Arrange */
+        $department = Department::create([
+            'name'       => 'Finance',
+            'color'      => '#112233',
+            'creator_id' => $this->user->id,
+        ]);
+
+        $payload = [
+            'name' => 'Updated ' . $department->name,
+        ];
+
+        /* Act */
+        Livewire::actingAs($this->user)
+            ->test(ListDepartments::class)
+            ->mountAction(TestAction::make('edit')->table($department), $payload)
+            ->fillForm($payload)
+            ->callMountedAction();
+
+        /* Assert */
+        $this->assertDatabaseHas('employees_departments', [
+            'id'   => $department->id,
+            'name' => $payload['name'],
+        ]);
+    }
+
+    #[Test]
+    public function it_deletes_a_department(): void
+    {
+        /* Arrange */
+        $department = Department::create([
+            'name'       => 'Logistics',
+            'color'      => '#445566',
+            'creator_id' => $this->user->id,
+        ]);
+
+        /* Act */
+        Livewire::actingAs($this->user)
+            ->test(ListDepartments::class)
+            ->mountAction(TestAction::make('delete')->table($department))
+            ->callMountedAction();
+
+        /* Assert */
+        $this->assertSoftDeleted('employees_departments', [
+            'id' => $department->id,
+        ]);
+    }
+}

--- a/tests/Feature/Modules/Products/ProductCrudTest.php
+++ b/tests/Feature/Modules/Products/ProductCrudTest.php
@@ -7,14 +7,16 @@ use Filament\Actions\Testing\TestAction;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Livewire\Livewire;
+use Modules\Core\Enums\ProductType;
+use Modules\Core\Models\Category;
+use Modules\Core\Models\Company;
+use Modules\Core\Models\Currency;
+use Modules\Core\Models\Product;
+use Modules\Core\Models\UOM;
+use Modules\Core\Models\UOMCategory;
+use Modules\Products\Filament\Resources\ProductResource\Pages\ListProducts;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
-use Webkul\Product\Enums\ProductType;
-use Webkul\Product\Filament\Resources\ProductResource\Pages\ListProducts;
-use Webkul\Product\Models\Category;
-use Webkul\Product\Models\Product;
-use Webkul\Support\Models\Company;
-use Webkul\Support\Models\UOM;
 
 /**
  * @group smoke
@@ -27,23 +29,82 @@ class ProductCrudTest extends TestCase
     {
         parent::setUp();
 
-        // Prevent mass assignment issues in tests when using factories
         Model::unguard();
 
         $this->user = User::factory()->create();
 
-        // Ensure required related records exist for form defaults/relationships
-        UOM::factory()->create();
+        $this->user->forceFill([
+            'resource_permission' => 'global',
+        ])->save();
+
+        $currency = Currency::create([
+            'name'           => 'USD',
+            'symbol'         => '$',
+            'iso_numeric'    => 840,
+            'decimal_places' => 2,
+            'full_name'      => 'US Dollar',
+            'rounding'       => 0.00,
+            'active'         => true,
+        ]);
+
+        $uomCategory = UOMCategory::create([
+            'name' => 'Unit',
+        ]);
+
+        UOM::create([
+            'name'        => 'Units',
+            'type'        => 'unit',
+            'factor'      => 1,
+            'rounding'    => 0,
+            'category_id' => $uomCategory->id,
+        ]);
+
+        $company = Company::create([
+            'name'        => 'Acme Corp',
+            'company_id'  => (string) Str::uuid(),
+            'email'       => 'info@example.com',
+            'currency_id' => $currency->id,
+            'creator_id'  => $this->user->id,
+        ]);
+
+        $this->user->forceFill([
+            'default_company_id' => $company->id,
+        ])->save();
+
         Category::factory()->create();
-        Company::factory()->create();
     }
 
     #[Test]
     public function it_lists_products(): void
     {
         /* Arrange */
-        $goods   = Product::factory()->create(['type' => ProductType::GOODS]);
-        $service = Product::factory()->create(['type' => ProductType::SERVICE]);
+        $category = Category::first();
+        $company  = Company::first();
+        $uom      = UOM::first();
+
+        $goods = Product::create([
+            'name'        => 'Goods Item',
+            'type'        => ProductType::GOODS->value,
+            'price'       => 25.00,
+            'cost'        => 10.00,
+            'category_id' => $category->id,
+            'company_id'  => $company->id,
+            'uom_id'      => $uom->id,
+            'uom_po_id'   => $uom->id,
+            'creator_id'  => $this->user->id,
+        ]);
+
+        $service = Product::create([
+            'name'        => 'Service Item',
+            'type'        => ProductType::SERVICE->value,
+            'price'       => 40.00,
+            'cost'        => 0.00,
+            'category_id' => $category->id,
+            'company_id'  => $company->id,
+            'uom_id'      => $uom->id,
+            'uom_po_id'   => $uom->id,
+            'creator_id'  => $this->user->id,
+        ]);
 
         /* Act */
         $component = Livewire::actingAs($this->user)
@@ -89,9 +150,20 @@ class ProductCrudTest extends TestCase
     public function it_updates_a_product(): void
     {
         /* Arrange */
-        $product = Product::factory()->create([
-            'type'  => ProductType::GOODS,
-            'price' => 10.00,
+        $category = Category::first();
+        $company  = Company::first();
+        $uom      = UOM::first();
+
+        $product = Product::create([
+            'name'        => 'Inventory Item',
+            'type'        => ProductType::GOODS->value,
+            'price'       => 10.00,
+            'cost'        => 5.00,
+            'category_id' => $category->id,
+            'company_id'  => $company->id,
+            'uom_id'      => $uom->id,
+            'uom_po_id'   => $uom->id,
+            'creator_id'  => $this->user->id,
         ]);
 
         $payload = [
@@ -118,7 +190,21 @@ class ProductCrudTest extends TestCase
     public function it_deletes_a_product(): void
     {
         /* Arrange */
-        $product = Product::factory()->create();
+        $category = Category::first();
+        $company  = Company::first();
+        $uom      = UOM::first();
+
+        $product = Product::create([
+            'name'        => 'Disposable Item',
+            'type'        => ProductType::GOODS->value,
+            'price'       => 15.00,
+            'cost'        => 7.00,
+            'category_id' => $category->id,
+            'company_id'  => $company->id,
+            'uom_id'      => $uom->id,
+            'uom_po_id'   => $uom->id,
+            'creator_id'  => $this->user->id,
+        ]);
 
         /* Act */
         $component = Livewire::actingAs($this->user)

--- a/tests/Feature/Modules/Projects/ProjectCrudTest.php
+++ b/tests/Feature/Modules/Projects/ProjectCrudTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature\Modules\Projects;
+
+use App\Models\User;
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Modules\Projects\Filament\Resources\ProjectResource\Pages\ListProjects;
+use Modules\Projects\Models\Project;
+use Modules\Projects\Models\ProjectStage;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * @group smoke
+ */
+class ProjectCrudTest extends TestCase
+{
+    protected User $user;
+
+    protected ProjectStage $stage;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Model::unguard();
+
+        $this->user = User::factory()->create();
+
+        $this->user->forceFill([
+            'resource_permission' => 'global',
+        ])->save();
+
+        $this->stage = ProjectStage::create([
+            'name'        => 'Planning',
+            'sort'        => 1,
+            'is_active'   => true,
+            'is_collapsed'=> false,
+            'creator_id'  => $this->user->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_lists_projects(): void
+    {
+        /* Arrange */
+        $activeProject = Project::create([
+            'name'       => 'Implementation',
+            'stage_id'   => $this->stage->id,
+            'is_active'  => true,
+            'user_id'    => $this->user->id,
+            'creator_id' => $this->user->id,
+        ]);
+
+        $archivedProject = Project::create([
+            'name'       => 'Archived Project',
+            'stage_id'   => $this->stage->id,
+            'is_active'  => false,
+            'user_id'    => $this->user->id,
+            'creator_id' => $this->user->id,
+        ]);
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(ListProjects::class);
+
+        /* Assert */
+        $component->assertCanSeeTableRecords([$activeProject, $archivedProject]);
+    }
+
+    #[Test]
+    public function it_creates_a_project(): void
+    {
+        /* Arrange */
+        $payload = [
+            'name'     => 'Project ' . Str::random(5),
+            'stage_id' => $this->stage->id,
+        ];
+
+        /* Act */
+        Livewire::actingAs($this->user)
+            ->test(ListProjects::class)
+            ->mountAction('create')
+            ->fillForm($payload)
+            ->callMountedAction();
+
+        /* Assert */
+        $this->assertDatabaseHas('projects_projects', [
+            'name'     => $payload['name'],
+            'stage_id' => $this->stage->id,
+        ]);
+    }
+
+    #[Test]
+    public function it_updates_a_project(): void
+    {
+        /* Arrange */
+        $project = Project::create([
+            'name'       => 'Migration',
+            'stage_id'   => $this->stage->id,
+            'is_active'  => true,
+            'user_id'    => $this->user->id,
+            'creator_id' => $this->user->id,
+        ]);
+
+        $payload = [
+            'name' => 'Updated ' . $project->name,
+        ];
+
+        /* Act */
+        Livewire::actingAs($this->user)
+            ->test(ListProjects::class)
+            ->mountAction(TestAction::make('edit')->table($project), $payload)
+            ->fillForm($payload)
+            ->callMountedAction();
+
+        /* Assert */
+        $this->assertDatabaseHas('projects_projects', [
+            'id'   => $project->id,
+            'name' => $payload['name'],
+        ]);
+    }
+
+    #[Test]
+    public function it_deletes_a_project(): void
+    {
+        /* Arrange */
+        $project = Project::create([
+            'name'       => 'Cleanup',
+            'stage_id'   => $this->stage->id,
+            'is_active'  => true,
+            'user_id'    => $this->user->id,
+            'creator_id' => $this->user->id,
+        ]);
+
+        /* Act */
+        Livewire::actingAs($this->user)
+            ->test(ListProjects::class)
+            ->mountAction(TestAction::make('delete')->table($project))
+            ->callMountedAction();
+
+        /* Assert */
+        $this->assertSoftDeleted('projects_projects', [
+            'id' => $project->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- update the product resource smoke test to bootstrap dependencies and work with the current module namespaces
- add CRUD coverage for the core category and department Filament resources
- add CRUD coverage for the projects module list page

## Testing
- not run (composer install requires a GitHub token to download dependencies)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690da4a4e9a483299045b25a33aa4c25)