### PR TITLE
Add CRM Filament resource CRUD feature tests

### DIFF
--- a/tests/Feature/Modules/Crm/IndustryCrudTest.php
+++ b/tests/Feature/Modules/Crm/IndustryCrudTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature\Modules\Crm;
+
+use App\Models\User;
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Modules\Crm\Filament\Resources\IndustryResource\Pages\ManageIndustries;
+use Modules\Crm\Models\Industry;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * @group smoke
+ */
+class IndustryCrudTest extends TestCase
+{
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Model::unguard();
+
+        $this->user = User::factory()->create();
+
+        $this->user->forceFill([
+            'resource_permission' => 'global',
+        ])->save();
+    }
+
+    #[Test]
+    public function it_lists_industries(): void
+    {
+        /* Arrange */
+        $visibleIndustry = Industry::factory()->create();
+        $otherIndustry   = Industry::factory()->create();
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(ManageIndustries::class);
+
+        /* Assert */
+        $component->assertCanSeeTableRecords([$visibleIndustry])
+            ->assertCanSeeTableRecords([$otherIndustry]);
+    }
+
+    #[Test]
+    public function it_creates_an_industry(): void
+    {
+        /* Arrange */
+        $payload = [
+            'name'        => 'Industry ' . Str::random(5),
+            'description' => 'Desc ' . Str::random(5),
+        ];
+
+        /* Act */
+        Livewire::actingAs($this->user)
+            ->test(ManageIndustries::class)
+            ->mountAction('create')
+            ->fillForm($payload)
+            ->callMountedAction();
+
+        /* Assert */
+        $this->assertDatabaseHas('partners_industries', [
+            'name'        => $payload['name'],
+            'description' => $payload['description'],
+        ]);
+    }
+
+    #[Test]
+    public function it_updates_an_industry(): void
+    {
+        /* Arrange */
+        $industry = Industry::factory()->create();
+
+        $payload = [
+            'name'        => 'Updated ' . $industry->name,
+            'description' => 'Updated ' . $industry->description,
+        ];
+
+        /* Act */
+        Livewire::actingAs($this->user)
+            ->test(ManageIndustries::class)
+            ->mountAction(TestAction::make('edit')->table($industry), $payload)
+            ->fillForm($payload)
+            ->callMountedAction();
+
+        /* Assert */
+        $this->assertDatabaseHas('partners_industries', [
+            'id'          => $industry->id,
+            'name'        => $payload['name'],
+            'description' => $payload['description'],
+        ]);
+    }
+
+    #[Test]
+    public function it_soft_deletes_an_industry(): void
+    {
+        /* Arrange */
+        $industry = Industry::factory()->create();
+
+        /* Act */
+        Livewire::actingAs($this->user)
+            ->test(ManageIndustries::class)
+            ->mountAction(TestAction::make('delete')->table($industry))
+            ->callMountedAction();
+
+        /* Assert */
+        $this->assertSoftDeleted('partners_industries', [
+            'id' => $industry->id,
+        ]);
+    }
+}

--- a/tests/Feature/Modules/Crm/TagCrudTest.php
+++ b/tests/Feature/Modules/Crm/TagCrudTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature\Modules\Crm;
+
+use App\Models\User;
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Modules\Crm\Filament\Resources\TagResource\Pages\ManageTags;
+use Modules\Crm\Models\Tag;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * @group smoke
+ */
+class TagCrudTest extends TestCase
+{
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Model::unguard();
+
+        $this->user = User::factory()->create();
+
+        $this->user->forceFill([
+            'resource_permission' => 'global',
+        ])->save();
+    }
+
+    #[Test]
+    public function it_lists_tags(): void
+    {
+        /* Arrange */
+        $visibleTag = Tag::factory()->create();
+        $otherTag   = Tag::factory()->create();
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(ManageTags::class);
+
+        /* Assert */
+        $component->assertCanSeeTableRecords([$visibleTag])
+            ->assertCanSeeTableRecords([$otherTag]);
+    }
+
+    #[Test]
+    public function it_creates_a_tag(): void
+    {
+        /* Arrange */
+        $payload = [
+            'name'  => 'Tag ' . Str::random(5),
+            'color' => '#ff0000',
+        ];
+
+        /* Act */
+        Livewire::actingAs($this->user)
+            ->test(ManageTags::class)
+            ->mountAction('create')
+            ->fillForm($payload)
+            ->callMountedAction();
+
+        /* Assert */
+        $this->assertDatabaseHas('partners_tags', [
+            'name'  => $payload['name'],
+            'color' => $payload['color'],
+        ]);
+    }
+
+    #[Test]
+    public function it_updates_a_tag(): void
+    {
+        /* Arrange */
+        $tag = Tag::factory()->create();
+
+        $payload = [
+            'name'  => 'Updated ' . $tag->name,
+            'color' => '#00ff00',
+        ];
+
+        /* Act */
+        Livewire::actingAs($this->user)
+            ->test(ManageTags::class)
+            ->mountAction(TestAction::make('edit')->table($tag), $payload)
+            ->fillForm($payload)
+            ->callMountedAction();
+
+        /* Assert */
+        $this->assertDatabaseHas('partners_tags', [
+            'id'    => $tag->id,
+            'name'  => $payload['name'],
+            'color' => $payload['color'],
+        ]);
+    }
+
+    #[Test]
+    public function it_soft_deletes_a_tag(): void
+    {
+        /* Arrange */
+        $tag = Tag::factory()->create();
+
+        /* Act */
+        Livewire::actingAs($this->user)
+            ->test(ManageTags::class)
+            ->mountAction(TestAction::make('delete')->table($tag))
+            ->callMountedAction();
+
+        /* Assert */
+        $this->assertSoftDeleted('partners_tags', [
+            'id' => $tag->id,
+        ]);
+    }
+}

--- a/tests/Feature/Modules/Crm/TitleCrudTest.php
+++ b/tests/Feature/Modules/Crm/TitleCrudTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature\Modules\Crm;
+
+use App\Models\User;
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Modules\Crm\Filament\Resources\TitleResource\Pages\ManageTitles;
+use Modules\Crm\Models\Title;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+/**
+ * @group smoke
+ */
+class TitleCrudTest extends TestCase
+{
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Model::unguard();
+
+        $this->user = User::factory()->create();
+
+        $this->user->forceFill([
+            'resource_permission' => 'global',
+        ])->save();
+    }
+
+    #[Test]
+    public function it_lists_titles(): void
+    {
+        /* Arrange */
+        $visibleTitle = Title::factory()->create();
+        $otherTitle   = Title::factory()->create();
+
+        /* Act */
+        $component = Livewire::actingAs($this->user)
+            ->test(ManageTitles::class);
+
+        /* Assert */
+        $component->assertCanSeeTableRecords([$visibleTitle])
+            ->assertCanSeeTableRecords([$otherTitle]);
+    }
+
+    #[Test]
+    public function it_creates_a_title(): void
+    {
+        /* Arrange */
+        $payload = [
+            'name'       => 'Title ' . Str::random(5),
+            'short_name' => 'Short ' . Str::random(3),
+        ];
+
+        /* Act */
+        Livewire::actingAs($this->user)
+            ->test(ManageTitles::class)
+            ->mountAction('create')
+            ->fillForm($payload)
+            ->callMountedAction();
+
+        /* Assert */
+        $this->assertDatabaseHas('partners_titles', [
+            'name'       => $payload['name'],
+            'short_name' => $payload['short_name'],
+        ]);
+    }
+
+    #[Test]
+    public function it_updates_a_title(): void
+    {
+        /* Arrange */
+        $title = Title::factory()->create();
+
+        $payload = [
+            'name'       => 'Updated ' . $title->name,
+            'short_name' => 'Updated ' . $title->short_name,
+        ];
+
+        /* Act */
+        Livewire::actingAs($this->user)
+            ->test(ManageTitles::class)
+            ->mountAction(TestAction::make('edit')->table($title), $payload)
+            ->fillForm($payload)
+            ->callMountedAction();
+
+        /* Assert */
+        $this->assertDatabaseHas('partners_titles', [
+            'id'         => $title->id,
+            'name'       => $payload['name'],
+            'short_name' => $payload['short_name'],
+        ]);
+    }
+
+    #[Test]
+    public function it_deletes_a_title(): void
+    {
+        /* Arrange */
+        $title = Title::factory()->create();
+
+        /* Act */
+        Livewire::actingAs($this->user)
+            ->test(ManageTitles::class)
+            ->mountAction(TestAction::make('delete')->table($title))
+            ->callMountedAction();
+
+        /* Assert */
+        $this->assertDatabaseMissing('partners_titles', [
+            'id' => $title->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add smoke-level CRUD tests for the CRM Title, Tag, and Industry Filament resources
- cover listing visibility, modal-driven create/update flows, and deletion handling for each resource

## Testing
- not run (composer install requires GitHub credentials in this environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690da9e2e694832997f61ab5241bc50f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for CRM management operations including industry, tag, and title functionality to ensure reliable list, create, update, and delete operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->